### PR TITLE
Add a DisableSQLAutocreateSchema method to disable schema creation

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -423,7 +423,7 @@ func (c *Collection) Run(db DB, a ...string) (oldVersion, newVersion int64, err 
 		return
 	}
 	if !exists {
-		err = fmt.Errorf("table %q does not exists; did you run init?", c.tableName)
+		err = fmt.Errorf("table %q does not exist; did you run init?", c.tableName)
 		return
 	}
 
@@ -605,6 +605,14 @@ func (c *Collection) down(db DB, tx *pg.Tx, migrations []*Migration, oldVersion 
 	return c.runDown(db, tx, m)
 }
 
+func (c *Collection) schemaExists(db DB) (bool, error) {
+	schema, _ := c.schemaTableName()
+	return db.Model().
+		Table("information_schema.schemata").
+		Where("schema_name = '?'", pg.SafeQuery(schema)).
+		Exists()
+}
+
 func (c *Collection) tableExists(db DB) (bool, error) {
 	schema, table := c.schemaTableName()
 	return db.Model().
@@ -637,10 +645,17 @@ func (c *Collection) SetVersion(db DB, version int64) error {
 
 func (c *Collection) createTable(db DB) error {
 	schema, _ := c.schemaTableName()
+
 	if schema != "public" {
-		_, err := db.Exec(`CREATE SCHEMA IF NOT EXISTS ?`, pg.SafeQuery(schema))
+		exists, err := c.schemaExists(db)
 		if err != nil {
 			return err
+		}
+		if !exists {
+			_, err := db.Exec(`CREATE SCHEMA IF NOT EXISTS ?`, pg.SafeQuery(schema))
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/collection.go
+++ b/collection.go
@@ -644,22 +644,19 @@ func (c *Collection) SetVersion(db DB, version int64) error {
 }
 
 func (c *Collection) createTable(db DB) error {
-	schema, _ := c.schemaTableName()
-
-	if schema != "public" {
-		exists, err := c.schemaExists(db)
+	exists, err := c.schemaExists(db)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		schema, _ := c.schemaTableName()
+		_, err := db.Exec(`CREATE SCHEMA IF NOT EXISTS ?`, pg.SafeQuery(schema))
 		if err != nil {
 			return err
 		}
-		if !exists {
-			_, err := db.Exec(`CREATE SCHEMA IF NOT EXISTS ?`, pg.SafeQuery(schema))
-			if err != nil {
-				return err
-			}
-		}
 	}
 
-	_, err := db.Exec(`
+	_, err = db.Exec(`
 		CREATE TABLE IF NOT EXISTS ? (
 			id serial,
 			version bigint,


### PR DESCRIPTION
At the time of this writing (latest release: [v8.0.2](https://github.com/go-pg/migrations/releases/tag/v8.0.2)), there is a line of code that ensures the creation of the schema (if not exists) when creating the table that stores the list of migrations executed:

```
_, err := db.Exec(`CREATE SCHEMA IF NOT EXISTS ?`, pg.SafeQuery(schema))
```

Source: https://github.com/go-pg/migrations/blob/v8.0.2/collection.go#L641

It is executed only if the targeted `schema` is not `public`.

In this PR, I'm proposing a new option that allows to disable this behavior, and require that the schema exists beforehand instead, or the "init" step fails.

This is really helpful in situations where the current PostgreSQL user doesn't have the `CREATE` privilege at the database level (hence they can't create new schemas) but only the `CREATE` privilege on a specific schema created beforehand by another superuser. Without this new option, the line above would fail (although the schema exists) and there would be no way to use this library.

The new `DisableSQLAutocreateSchema()` method is modeled on the existing `DisableSQLAutodiscover()` method, and can be used like this:

```go
collection.DisableSQLAutocreateSchema(true)
collection.SetTableName("myschema.gopg_migrations")
collection.Run(db, "init")
```

In this example, if `myschema` does not exist beforehand, an error is returned and the schema is not automatically created.

Additionally, I removed the special handling of the `public` schema as it may or may not be there, as any other schema (it's common to have the `public` schema since it is added by default in new PostgreSQL databases, but it could have been dropped...). I'm not sure what the rationale was for this exception, so don't hesitate to tell me if I'm going in the wrong direction there.

New behavior:

```go
collection.SetTableName("gopg_migrations")
collection.Run(db, "init") // Will now run "CREATE SCHEMA IF NOT EXISTS public"
```

**Edit** This is a fallback PR if case https://github.com/go-pg/migrations/pull/106 is rejected.